### PR TITLE
refatora authors para seguir o padrão das views de rental

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AuthorsController < ApplicationController
   def index
     @authors = Author.all
@@ -40,12 +42,11 @@ class AuthorsController < ApplicationController
     @author = Author.find(params[:id])
     if @author.books.exists?
       flash[:danger] = t(".fail")
-      redirect_to authors_path
     else
       @author.destroy
       flash[:success] = t(".success")
-      redirect_to authors_path
     end
+    redirect_to authors_path
   end
 
   private

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Author < ApplicationRecord
   has_many :books
 

--- a/app/views/authors/_form.html.erb
+++ b/app/views/authors/_form.html.erb
@@ -1,10 +1,21 @@
 <div class="container">
-<div class="card mx-auto" style="width: 15rem;">
-  <div class="card-body">
-    <%= form_with(model: @author, local: true) do |f| %>
+  <% if @author.errors.any? %>
+    <div id="error-explanation">
+      <h5><%= t('authors.errors.title', count: @author.errors.count) %></h5>
+      <p class="error-message"><%= @author.errors.full_messages.to_sentence %></p>
+    </div>
+  <% end %>
+
+  <div class="card mx-auto" style="width: 15rem;">
+    <div class="card-body">
+      <%= form_with(model: @author, local: true) do |f| %>
         <%= f.label :name, t('.label.name'), class:"form_label" %>
             <%= error_tag @author, :name %>
         <%= f.text_field :name, placeholder: t('.placeholder.name') , class:"form_controll" %>
+
+        <%= f.label :name, t('.label.biography'), class:"form_label" %>
+            <%= error_tag @author, :biography %>
+        <%= f.text_field :biography, placeholder: t('.placeholder.biography') , class:"form_controll" %>
 
         <div class="input-group-btn">
           <%= f.submit button_text,  class:"btn btn-outline-success btn-sm mt-2" %>
@@ -13,6 +24,8 @@
           <% else %>
             <%= link_to t('links.back'), authors_path, class: "btn btn-outline-dark btn-sm mt-2" %>
           <% end %>
-      </div>
-  <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/authors/edit.html.erb
+++ b/app/views/authors/edit.html.erb
@@ -1,2 +1,2 @@
 <h1 class="text-center"><%= t('.title') %> </h1>
-<%= render partial: 'form', locals: {author: @author, button_text: t('links.update')}%>
+<%= render partial: 'form', locals: {author: @author, button_text: t('links.update')} %>

--- a/app/views/authors/index.html.erb
+++ b/app/views/authors/index.html.erb
@@ -1,13 +1,14 @@
   <% if @authors.empty? %>
- <p>'Nenhum Autor Cadastrado'</p>
+ <p><%= t('.no_authors') %></p>
   <% else %>
+  <h5><%= t('.title') %> </h5>
   <% @authors.each do |author| %>
 <div class="card rounded-circle border border-dark" style="width: 18rem;">
 </div>
   <div class="card-body">
-    <h5>Nome: <%= link_to author.name, author_path(author)%> </h5>
+    <h5>Nome: <%= link_to author.name, author_path(author) %> </h5>
   </div>
  <% end %>
 <% end %>
-<%= link_to t('links.create'), new_author_path, class:"btn btn-outline-dark btn-sm"%>
-<%= link_to t('links.back'), root_path, class:"btn btn-outline-dark btn-sm"%>
+<%= link_to t('links.create'), new_author_path, class:"btn btn-outline-dark btn-sm" %>
+<%= link_to t('links.back'), root_path, class:"btn btn-outline-dark btn-sm" %>

--- a/app/views/authors/new.html.erb
+++ b/app/views/authors/new.html.erb
@@ -1,2 +1,2 @@
 <h1 class="text-center"><%= t('.title') %> </h1>
-<%= render partial: 'form', locals: {author: @author, button_text: t('links.create')}%>
+<%= render partial: 'form', locals: {author: @author, button_text: t('links.create')} %>

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -1,12 +1,23 @@
 
   <div class="card border border-5 mt-3 mx-auto" style="width: 27rem;">
     <div class="card-body text-justify mx-auto">
-      <h5 class="card-title">Nome: <%= @author.name %></h5>
+
+      <div class="card-title d-flex align-items-center">
+       <h5 class="me-2"><%= "#{t('.name')}: " %></h5>
+       <span><%= @author.name %></span>
+      </div>
+
+      <div class="card-title d-flex align-items-center">
+        <h5 class="me-2"><%= "#{t('.biography')}: " %></h5>
+        <span><%= @author.biography %></span>
+      </div>
+    </div>
+  </div>
     </div>
   </div>
 
 <div class="inner-flex">
   <%= link_to t('links.edit'), edit_author_path(@author), class:"btn btn-outline-dark" %>
-  <%= button_to  t('links.delete'), @author, method: :delete, data: { confirm: 'Você tem certeza que deseja excluir este autor?' }, class: 'btn btn-danger' %>
+  <%= button_to  t('links.delete'), @author, method: :delete, class: 'btn btn-danger' %>
   <%= link_to t('links.back'), authors_path, class:"btn btn-outline-dark" %>
 </div>

--- a/config/locales/author.yml
+++ b/config/locales/author.yml
@@ -7,11 +7,17 @@
       update: Atualizar
       create: Cadastrar
     authors:
+      errors:
+        title:
+        one: "%{count} erro proibiu o cadastro desse autor:"
+        other: "%{count} erros proibiram o cadastro desse autor:"
       form:
         label:
           name: Nome do Autor
+          biography: Biografia
         placeholder:
           name: Autor Generico
+          biography: Exemplo de Biografia
 
       new:
         title: Formulário de Cadastro de Autor
@@ -27,6 +33,15 @@
       destroy:
         success: Autor excluido com sucesso
         fail: Autor não pode ser excluido, pois existem livros associados
+
+      index:
+        no_authors: Nenhum Author Cadastrado
+        title: Lista de Autores Cadastrados
+
+      show:
+        author: Autor
+        name: Nome
+        biography: Biografia
 
       edit:
         title: Formulário de Atualização de Autor

--- a/spec/factories/authors.rb
+++ b/spec/factories/authors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :author do
     name { "Fernando Pessoa" }
@@ -5,7 +7,7 @@ FactoryBot.define do
 
     trait :with_book do
       after(:create) do |author|
-        create(:book, author: author)
+        create(:book, author:)
       end
     end
 

--- a/spec/features/authors_spec.rb
+++ b/spec/features/authors_spec.rb
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.feature "Authors", type: :feature do
   let!(:author_with_book) { create(:author, :with_book) }
   let!(:author_without_book) { create(:author, :camilo) }
-
 
   let!(:user) { create(:user, :maria) }
   let(:user_with_rental) { create(:user, :with_rental) }

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Author, type: :model do

--- a/spec/requests/authors_spec.rb
+++ b/spec/requests/authors_spec.rb
@@ -1,4 +1,6 @@
-require 'rails_helper'
+# frozen_string_literal: true
+
+require "rails_helper"
 
 RSpec.describe "Authors", type: :request do
   describe "GET /index" do


### PR DESCRIPTION
## O que mudou
Refatora views de autores

## Solução proposta
Faz diversas melhorias, adicionando titulos e traduções que estavam faltando

## Como testar
### Testando pelo navegador
1. Subir o projeto usando ```docker compose run web bash```
2. Acesse http://localhost:3000/authors
3. Agora é possivel visualizar o titulo 'Lista de Autores Cadastrados'
4. E durante o cadastro de um autor é possível adicionar a biografia

## Riscos
Sem riscos

## Impactos negativos previstos
Nenhum Impacto previsto

## Instruções para deploy
Nenhuma instrução adicional

## Instruções para retorno
rollback padrão desse PR
